### PR TITLE
OK-3710 Handle ignored and abandoned statuses

### DIFF
--- a/pkg/github/runners/message-processor.go
+++ b/pkg/github/runners/message-processor.go
@@ -15,6 +15,12 @@ import (
 	"github.com/macstadium/orka-github-actions-integration/pkg/logging"
 )
 
+const (
+	cancelledStatus = "canceled"
+	ignoredStatus   = "ignored"
+	abandonedStatus = "abandoned"
+)
+
 func NewRunnerMessageProcessor(ctx context.Context, runnerManager RunnerManagerInterface, runnerProvisioner RunnerProvisionerInterface, runnerScaleSet *types.RunnerScaleSet) *RunnerMessageProcessor {
 	return &RunnerMessageProcessor{
 		ctx:                ctx,
@@ -126,7 +132,7 @@ func (p *RunnerMessageProcessor) processRunnerMessage(message *types.RunnerScale
 
 			p.logger.Infof("Job completed message received for RunnerRequestId: %d, RunnerId: %d, RunnerName: %s, with Result: %s", jobCompleted.RunnerRequestId, jobCompleted.RunnerId, jobCompleted.RunnerName, jobCompleted.Result)
 
-			if jobCompleted.Result == "canceled" {
+			if jobCompleted.Result == cancelledStatus || jobCompleted.Result == ignoredStatus || jobCompleted.Result == abandonedStatus {
 				p.canceledJobs[jobCompleted.RunnerRequestId] = true
 				p.runnerProvisioner.DeprovisionRunner(p.ctx, fmt.Sprintf("%s-%d-%d", p.runnerScaleSetName, jobCompleted.RunnerRequestId, jobCompleted.WorkflowRunId))
 			}


### PR DESCRIPTION
## Description
 
These statuses are not handled at the moment.
When a job completes with either of them the runner is not deprovisioned. This results in the runner and the VM taking resources from the Orka Cluster. Handle ignored and abandoned statuses as cancelled. This ensures the runner and the VM are deprovisioned. And the cluster has the resources to run other jobs with other runners.

## Testing

Testing is not easy as these statuses cannot be reproduced in our labs.
They need to be mocked for the sake of testing.