### PR TITLE
OK-3711 Reverse the order of creating the runner and VM

### DIFF
--- a/pkg/runner-provisioner/provisioner.go
+++ b/pkg/runner-provisioner/provisioner.go
@@ -51,11 +51,6 @@ var commands_template = []string{
 }
 
 func (p *RunnerProvisioner) ProvisionRunner(ctx context.Context, runnerName string) error {
-	jitConfig, err := p.createRunner(ctx, runnerName)
-	if err != nil {
-		return err
-	}
-
 	p.logger.Infof("deploying Orka VM with name %s", runnerName)
 	vmResponse, err := p.orkaClient.DeployVM(ctx, runnerName, p.envData.OrkaVMConfig)
 	if err != nil {
@@ -69,6 +64,13 @@ func (p *RunnerProvisioner) ProvisionRunner(ctx context.Context, runnerName stri
 	if err != nil {
 		return err
 	}
+
+	p.logger.Infof("creating runner with name %s", runnerName)
+	jitConfig, err := p.createRunner(ctx, runnerName)
+	if err != nil {
+		return err
+	}
+	p.logger.Infof("created runner with name %s", runnerName)
 
 	cancelContext := p.createCancelContext(ctx, runnerName)
 


### PR DESCRIPTION
## Description

Creating the runner after the VM ensures that the runner does not stay in the GitHub UI in an "unknown/not ready" state. While this does not cause any issues, it might be misleading for users as they might think the runner is orhpaned. The new logic creates the runner only after there is a running VM and it has a valid IP address.

## Testing

### Case 1 - Standard run

1. Connect the runner
2. Start a job
3. It should complete as expected

### Case 2 - Cancel run

1. Connect the runner
2. Start a job
3. Cancel the run - try with both before the VM is deployed and after
4. No VM and runner should be present after the cancellation

### Case 3 - Not enough resources

1. Connect the runner
2. Cordon all nodes
3. Start a job
4. The VM should not be deployed
5. No runner is present in the UI
6. Uncordon one of the nodes
7. The vm is deployed, the runner is created and the job completes