### PR TITLE
Improve Runner Provisioning

### DIFF
--- a/pkg/github/runners/message-processor.go
+++ b/pkg/github/runners/message-processor.go
@@ -105,7 +105,7 @@ func (p *RunnerMessageProcessor) processRunnerMessage(message *types.RunnerScale
 			p.logger.Infof("Job assigned message received for RunnerRequestId: %d", jobAssigned.RunnerRequestId)
 
 			go func() {
-				for attempt := 1; !p.canceledJobs[jobAssigned.RunnerRequestId]; attempt++ {
+				for attempt := 1; !p.canceledJobs[jobAssigned.JobId]; attempt++ {
 					err := p.runnerProvisioner.ProvisionRunner(p.ctx)
 					if err == nil {
 						break
@@ -116,7 +116,7 @@ func (p *RunnerMessageProcessor) processRunnerMessage(message *types.RunnerScale
 					time.Sleep(15 * time.Second)
 				}
 
-				delete(p.canceledJobs, jobAssigned.RunnerRequestId)
+				delete(p.canceledJobs, jobAssigned.JobId)
 			}()
 		case "JobStarted":
 			var jobStarted types.JobStarted
@@ -133,7 +133,7 @@ func (p *RunnerMessageProcessor) processRunnerMessage(message *types.RunnerScale
 			p.logger.Infof("Job completed message received for RunnerRequestId: %d, RunnerId: %d, RunnerName: %s, with Result: %s", jobCompleted.RunnerRequestId, jobCompleted.RunnerId, jobCompleted.RunnerName, jobCompleted.Result)
 
 			if jobCompleted.Result == cancelledStatus || jobCompleted.Result == ignoredStatus || jobCompleted.Result == abandonedStatus {
-				p.canceledJobs[jobCompleted.RunnerRequestId] = true
+				p.canceledJobs[jobCompleted.JobId] = true
 				p.runnerProvisioner.DeprovisionRunner(p.ctx, jobCompleted.RunnerName)
 			}
 		default:

--- a/pkg/github/runners/message-processor.go
+++ b/pkg/github/runners/message-processor.go
@@ -95,7 +95,7 @@ func (p *RunnerMessageProcessor) processRunnerMessage(message *types.RunnerScale
 			if err := json.Unmarshal(message, &jobAvailable); err != nil {
 				return fmt.Errorf("could not decode job available message. %w", err)
 			}
-			p.logger.Infof("Job available message received for RunnerRequestId: %d", jobAvailable.RunnerRequestId)
+			p.logger.Infof("Job available message received for JobId: %s, RunnerRequestId: %d", jobAvailable.JobId, jobAvailable.RunnerRequestId)
 			availableJobs = append(availableJobs, jobAvailable.RunnerRequestId)
 		case "JobAssigned":
 			var jobAssigned types.JobAssigned
@@ -103,7 +103,7 @@ func (p *RunnerMessageProcessor) processRunnerMessage(message *types.RunnerScale
 				return fmt.Errorf("could not decode job assigned message. %w", err)
 			}
 
-			p.logger.Infof("Job assigned message received for RunnerRequestId: %d", jobAssigned.RunnerRequestId)
+			p.logger.Infof("Job assigned message received for JobId: %s, RunnerRequestId: %d", jobAssigned.JobId, jobAssigned.RunnerRequestId)
 
 			go func() {
 				jobId := jobAssigned.JobId
@@ -129,14 +129,14 @@ func (p *RunnerMessageProcessor) processRunnerMessage(message *types.RunnerScale
 			if err := json.Unmarshal(message, &jobStarted); err != nil {
 				return fmt.Errorf("could not decode job started message. %w", err)
 			}
-			p.logger.Infof("Job started message received for RunnerRequestId: %d and RunnerId: %d", jobStarted.RunnerRequestId, jobStarted.RunnerId)
+			p.logger.Infof("Job started message received for JobId: %s, RunnerRequestId: %d, RunnerId: %d", jobStarted.JobId, jobStarted.RunnerRequestId, jobStarted.RunnerId)
 		case "JobCompleted":
 			var jobCompleted types.JobCompleted
 			if err := json.Unmarshal(message, &jobCompleted); err != nil {
 				return fmt.Errorf("could not decode job completed message. %w", err)
 			}
 
-			p.logger.Infof("Job completed message received for RunnerRequestId: %d, RunnerId: %d, RunnerName: %s, with Result: %s", jobCompleted.RunnerRequestId, jobCompleted.RunnerId, jobCompleted.RunnerName, jobCompleted.Result)
+			p.logger.Infof("Job completed message received for JobId: %s, RunnerRequestId: %d, RunnerId: %d, RunnerName: %s, with Result: %s", jobCompleted.JobId, jobCompleted.RunnerRequestId, jobCompleted.RunnerId, jobCompleted.RunnerName, jobCompleted.Result)
 
 			if jobCompleted.JobId != "" && (jobCompleted.Result == cancelledStatus || jobCompleted.Result == ignoredStatus || jobCompleted.Result == abandonedStatus) {
 				p.canceledJobs[jobCompleted.JobId] = true

--- a/pkg/github/runners/message-processor.go
+++ b/pkg/github/runners/message-processor.go
@@ -106,7 +106,7 @@ func (p *RunnerMessageProcessor) processRunnerMessage(message *types.RunnerScale
 
 			go func() {
 				for attempt := 1; !p.canceledJobs[jobAssigned.RunnerRequestId]; attempt++ {
-					err := p.runnerProvisioner.ProvisionRunner(p.ctx, fmt.Sprintf("%s-%d-%d", p.runnerScaleSetName, jobAssigned.RunnerRequestId, jobAssigned.WorkflowRunId))
+					err := p.runnerProvisioner.ProvisionRunner(p.ctx)
 					if err == nil {
 						break
 					}
@@ -134,7 +134,7 @@ func (p *RunnerMessageProcessor) processRunnerMessage(message *types.RunnerScale
 
 			if jobCompleted.Result == cancelledStatus || jobCompleted.Result == ignoredStatus || jobCompleted.Result == abandonedStatus {
 				p.canceledJobs[jobCompleted.RunnerRequestId] = true
-				p.runnerProvisioner.DeprovisionRunner(p.ctx, fmt.Sprintf("%s-%d-%d", p.runnerScaleSetName, jobCompleted.RunnerRequestId, jobCompleted.WorkflowRunId))
+				p.runnerProvisioner.DeprovisionRunner(p.ctx, jobCompleted.RunnerName)
 			}
 		default:
 			p.logger.Infof("unknown job message type %s", messageType.MessageType)

--- a/pkg/github/runners/message-processor.go
+++ b/pkg/github/runners/message-processor.go
@@ -138,11 +138,8 @@ func (p *RunnerMessageProcessor) processRunnerMessage(message *types.RunnerScale
 
 			p.logger.Infof("Job completed message received for RunnerRequestId: %d, RunnerId: %d, RunnerName: %s, with Result: %s", jobCompleted.RunnerRequestId, jobCompleted.RunnerId, jobCompleted.RunnerName, jobCompleted.Result)
 
-			if jobCompleted.Result == cancelledStatus || jobCompleted.Result == ignoredStatus || jobCompleted.Result == abandonedStatus {
-				if jobCompleted.JobId != "" {
-					p.canceledJobs[jobCompleted.JobId] = true
-				}
-				p.runnerProvisioner.DeprovisionRunner(p.ctx, jobCompleted.RunnerName)
+			if jobCompleted.JobId != "" && (jobCompleted.Result == cancelledStatus || jobCompleted.Result == ignoredStatus || jobCompleted.Result == abandonedStatus) {
+				p.canceledJobs[jobCompleted.JobId] = true
 			}
 		default:
 			p.logger.Infof("unknown job message type %s", messageType.MessageType)

--- a/pkg/github/runners/types.go
+++ b/pkg/github/runners/types.go
@@ -31,7 +31,6 @@ type RunnerManager struct {
 
 type RunnerProvisionerInterface interface {
 	ProvisionRunner(ctx context.Context) error
-	DeprovisionRunner(ctx context.Context, name string)
 }
 
 type RunnerMessageProcessor struct {

--- a/pkg/github/runners/types.go
+++ b/pkg/github/runners/types.go
@@ -40,5 +40,5 @@ type RunnerMessageProcessor struct {
 	runnerManager      RunnerManagerInterface
 	runnerProvisioner  RunnerProvisionerInterface
 	runnerScaleSetName string
-	canceledJobs       map[int64]bool
+	canceledJobs       map[string]bool
 }

--- a/pkg/github/runners/types.go
+++ b/pkg/github/runners/types.go
@@ -30,7 +30,7 @@ type RunnerManager struct {
 }
 
 type RunnerProvisionerInterface interface {
-	ProvisionRunner(ctx context.Context, name string) error
+	ProvisionRunner(ctx context.Context) error
 	DeprovisionRunner(ctx context.Context, name string)
 }
 

--- a/pkg/github/types/job.go
+++ b/pkg/github/types/job.go
@@ -50,6 +50,7 @@ type JobMessageType struct {
 
 type JobMessageBase struct {
 	JobMessageType
+	JobId              int64     `json:"jobId"`
 	RunnerRequestId    int64     `json:"runnerRequestId"`
 	RepositoryName     string    `json:"repositoryName"`
 	OwnerName          string    `json:"ownerName"`

--- a/pkg/github/types/job.go
+++ b/pkg/github/types/job.go
@@ -50,7 +50,7 @@ type JobMessageType struct {
 
 type JobMessageBase struct {
 	JobMessageType
-	JobId              int64     `json:"jobId"`
+	JobId              string    `json:"jobId"`
 	RunnerRequestId    int64     `json:"runnerRequestId"`
 	RepositoryName     string    `json:"repositoryName"`
 	OwnerName          string    `json:"ownerName"`

--- a/pkg/orka/client.go
+++ b/pkg/orka/client.go
@@ -13,7 +13,7 @@ import (
 )
 
 type OrkaService interface {
-	DeployVM(ctx context.Context, vmName, vmConfig string) (*OrkaVMDeployResponseModel, error)
+	DeployVM(ctx context.Context, namePrefix, vmConfig string) (*OrkaVMDeployResponseModel, error)
 	DeleteVM(ctx context.Context, name string) error
 }
 
@@ -21,8 +21,8 @@ type OrkaClient struct {
 	envData *env.Data
 }
 
-func (client *OrkaClient) DeployVM(ctx context.Context, vmName, vmConfig string) (*OrkaVMDeployResponseModel, error) {
-	args := []string{"vm", "deploy", vmName, "--config", vmConfig, "-o", "json", "--namespace", client.envData.OrkaNamespace}
+func (client *OrkaClient) DeployVM(ctx context.Context, namePrefix, vmConfig string) (*OrkaVMDeployResponseModel, error) {
+	args := []string{"vm", "deploy", namePrefix, "--config", vmConfig, "--generate-name", "-o", "json", "--namespace", client.envData.OrkaNamespace}
 	if client.envData.OrkaVMMetadata != "" {
 		args = append(args, "--metadata", client.envData.OrkaVMMetadata)
 	}

--- a/pkg/runner-provisioner/provisioner.go
+++ b/pkg/runner-provisioner/provisioner.go
@@ -50,12 +50,14 @@ var commands_template = []string{
 	"echo 'Git Action Runner exited'",
 }
 
-func (p *RunnerProvisioner) ProvisionRunner(ctx context.Context, runnerName string) error {
-	p.logger.Infof("deploying Orka VM with name %s", runnerName)
-	vmResponse, err := p.orkaClient.DeployVM(ctx, runnerName, p.envData.OrkaVMConfig)
+func (p *RunnerProvisioner) ProvisionRunner(ctx context.Context) error {
+	p.logger.Infof("deploying Orka VM with prefix  %s", p.runnerScaleSet.Name)
+	vmResponse, err := p.orkaClient.DeployVM(ctx, p.runnerScaleSet.Name, p.envData.OrkaVMConfig)
 	if err != nil {
 		return err
 	}
+
+	runnerName := vmResponse.Name
 	p.logger.Infof("deployed Orka VM with name %s", runnerName)
 
 	defer p.deleteVM(ctx, runnerName)


### PR DESCRIPTION
## Description

**Note** - Looking at the commits one by one is recommended. They are all related and at the same time semi independent

**Cultprit**

The main issue comes from the fact that the runnerRequestID and the workflowRunID are not longer set.
They were used to uniquely identify Orka runners.
This causes a lot of issues. Like the inability to run multiple runners at the same time. Or not being able to delete a runner as it is being used.

**High level changes that are done:**
1. [Create VMs and runners with unique names](https://github.com/macstadium/orka-github-actions-integration/commit/2f9a622cb8f034e3e63176e662365cb28c2cbd84) 

The names were previously generated based on the runnerRequestId and workflowRunId.
However, these are assigned to 0 lately, which breaks all the logic that we have.
Instead let K8s deploy a VM with unique name and use that name for the runner.

2. [Use jobId to uniquely identify jobs](https://github.com/macstadium/orka-github-actions-integration/commit/60dcc1caddbc8907a940ffdb4a24f99b9c8f295d) 

This is not used by ARC, but it is returned by the API.
The runnerRequestIda and the workflowRunId are 0 at the moment, so it's not possible to use them.

## Implications

With the new changes it is possible that a runner is left idle if the job has been cancelled before a runner has been assigned to it. However, the runner is going to pick the next possible job and will then terminate.

## Testing

### Single Runner

1. Create a GH workflow like this 
```
name: Manual Single

on:
  workflow_dispatch:

jobs:
  run-echo:
    runs-on: github-runner
    steps:
      - name: Run echo command
        run: sleep 15

      - name: Run echo command
        run: sleep 15
```
2. Run a job. It should succeed. The runner and the VM should be deleted
3. Run a job. Cancel it right away. The runner and the VM are there and not removed
4. After the runner in (3) is ready run a job. No new runner is created, but the idle one is used. The runner and the VM should be deleted after completion
5. Run a job. Cancel it once execution starts. The execution should stop and the runner and VM are removed

### Multiple Runner

1. Create a GH workflow like this 
```
name: Manual Multiple

on:
  workflow_dispatch:

jobs:
  run-echo:
    runs-on: github-runner
    steps:
      - name: Run echo command
        run: sleep 15

  run-echo-again:
    runs-on: github-runner
    steps:
      - name: Run echo command
        run: echo 1
```
2. Run a job. It should succeed. The runners and the VMs need to be created in parallel, not sequentially. The runners and the VMs should be deleted
3. Run a job. Cancel it right away. The created runners and VMs are there and not removed
4. After the runner in (3) is ready run a job. The idle runners are used.  All runners and VMs are deleted after completion

### Free testing

Feel free to test this in any other way as well.
        