### PR TITLE
Access the cancel jobs map in a thread-safe fashion

### DIFF
--- a/pkg/github/runners/types.go
+++ b/pkg/github/runners/types.go
@@ -6,6 +6,7 @@ package runners
 
 import (
 	"context"
+	"sync"
 
 	"github.com/macstadium/orka-github-actions-integration/pkg/github/actions"
 	"github.com/macstadium/orka-github-actions-integration/pkg/github/messagequeue"
@@ -40,4 +41,5 @@ type RunnerMessageProcessor struct {
 	runnerProvisioner  RunnerProvisionerInterface
 	runnerScaleSetName string
 	canceledJobs       map[string]bool
+	canceledJobsMutex  sync.RWMutex
 }


### PR DESCRIPTION
As go routines are created during agent deployment it is possible that the map is accessed by multiple go routines.
This leaks to panics.
