### PR TITLE
Use exponential backoff to retry deletion of runners

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 )
 
 require (
+	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/go-logr/logr v1.3.0 // indirect
 	github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
+github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=

--- a/pkg/github/actions/runnerscaleset.go
+++ b/pkg/github/actions/runnerscaleset.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/http"
 
+	backoff "github.com/cenkalti/backoff/v4"
 	"github.com/macstadium/orka-github-actions-integration/pkg/github/types"
 )
 
@@ -38,7 +39,11 @@ func (client *ActionsClient) CreateRunnerScaleSet(ctx context.Context, runner *t
 func (client *ActionsClient) DeleteRunnerScaleSet(ctx context.Context, runnerScaleSetId int) error {
 	path := fmt.Sprintf("/%s/%d", scaleSetEndpoint, runnerScaleSetId)
 
-	_, err := RequestJSON[any, any](ctx, client, http.MethodDelete, path, nil)
+	operation := func() error {
+		_, err := RequestJSON[any, any](ctx, client, http.MethodDelete, path, nil)
 
-	return err
+		return err
+	}
+
+	return backoff.Retry(operation, backoff.NewExponentialBackOff())
 }


### PR DESCRIPTION
Introduces the [github.com/cenkalti/backoff/v4](https://pkg.go.dev/github.com/cenkalti/backoff/v4) dependency to support exponential backoff for retrying deletion of runners.

Currently uses the default configuration, as shared here:
```
// Default values for ExponentialBackOff.
const (
	DefaultInitialInterval     = 500 * time.Millisecond
	DefaultRandomizationFactor = 0.5
	DefaultMultiplier          = 1.5
	DefaultMaxInterval         = 60 * time.Second
	DefaultMaxElapsedTime      = 15 * time.Minute
)
```

There should be no impact to the existing plugin as designed, outside the fact that when the plugin fails, it will take a little longer to wrap up due to the retries if there are issues with deleting VMs.