### PR TITLE
Don't error out when unable to receive message

### DIFF
--- a/pkg/github/runners/manager.go
+++ b/pkg/github/runners/manager.go
@@ -140,6 +140,9 @@ func (m *RunnerManager) ProcessMessages(ctx context.Context, handler func(msg *t
 	for {
 		message, err := m.messageQueueManager.ReceiveNextMessage(ctx, m.lastMessageId)
 		if err != nil {
+			if ctx.Err() == context.Canceled {
+				return err
+			}
 			m.logger.Errorf("unable to get the next message from the message queue. %w", err)
 		}
 


### PR DESCRIPTION
Instead of returning an error, we will log the issue, and then proceed, which would identify the `message` as `nil`, return, and then keep going at the next incoming event. Ideally, this should just repeat the process until we can actually receive the next message.