### PR TITLE
Check correct node namespace on Orka Client creation

### DIFF
--- a/pkg/orka/client.go
+++ b/pkg/orka/client.go
@@ -70,7 +70,7 @@ func NewOrkaClient(envData *env.Data, ctx context.Context) (*OrkaClient, error) 
 
 	// The purpose of this call is to check the permissions of the provided token.
 	// If the command fails with an "Unauthorized" error, it indicates that the provided token is not valid.
-	_, err = exec.ExecStringCommand("orka3", []string{"node", "list"})
+	_, err = exec.ExecStringCommand("orka3", []string{"node", "list", "--namespace", envData.OrkaNamespace})
 	if err != nil {
 		if strings.Contains(err.Error(), "Unauthorized") {
 			return nil, fmt.Errorf("the provided token is not valid. Please provide a valid token")


### PR DESCRIPTION
## Overview

When initializing the Orka client, we run an `orka3 node list` to ensure that the token provided is valid. This was only run against the `orka-default` namespace. If a namespace is configured and the token does not have access to the default namespace, the check will fail despite the token having proper permissions and access. 

This change adds the namespace flag to the initial permissions check for the token. 

## Testing 

Steps to test this are as follows:
- Generate a custom namespace in Orka
- Move a node into the namespace
- Create a service account in the namespace
- Configure the `.env` file using these values
- Run `make run` 

The controller should spin up and accept jobs without errors. 