### PR TITLE
fix: Re-use existing runner scale set instead of panicking on startup

### DIFF
--- a/main.go
+++ b/main.go
@@ -70,22 +70,32 @@ func main() {
 		}
 	}()
 
-	runnerScaleSet, err := actionsClient.CreateRunnerScaleSet(ctx, &types.RunnerScaleSet{
-		Name:          runnerName,
-		RunnerGroupId: groupId,
-		Labels: []types.RunnerScaleSetLabel{
-			{
-				Name: runnerName,
-				Type: "System",
-			},
-		},
-		RunnerSetting: types.RunnerScaleSetSetting{
-			Ephemeral:     true,
-			DisableUpdate: true,
-		},
-	})
+	runnerScaleSet, err := actionsClient.GetRunnerScaleSet(ctx, groupId, runnerName)
 	if err != nil {
-		panic(fmt.Sprintf("unable to create runner %s, err: %s", runnerName, err.Error()))
+		panic(fmt.Sprintf("unable to look up runner scale set %s, err: %s", runnerName, err.Error()))
+	}
+
+	if runnerScaleSet != nil {
+		logger.Infof("found existing runner scale set %s (id: %d), re-using it", runnerName, runnerScaleSet.Id)
+	} else {
+		logger.Infof("no existing runner scale set found for %s, creating a new one", runnerName)
+		runnerScaleSet, err = actionsClient.CreateRunnerScaleSet(ctx, &types.RunnerScaleSet{
+			Name:          runnerName,
+			RunnerGroupId: groupId,
+			Labels: []types.RunnerScaleSetLabel{
+				{
+					Name: runnerName,
+					Type: "System",
+				},
+			},
+			RunnerSetting: types.RunnerScaleSetSetting{
+				Ephemeral:     true,
+				DisableUpdate: true,
+			},
+		})
+		if err != nil {
+			panic(fmt.Sprintf("unable to create runner %s, err: %s", runnerName, err.Error()))
+		}
 	}
 
 	runnerScaleSetIDs = append(runnerScaleSetIDs, runnerScaleSet.Id)


### PR DESCRIPTION
When a pod crashes or restarts without clean shutdown, the runner scale set remains registered in GitHub. According to https://github.com/actions/actions-runner-controller/discussions/3035, there's no GH API to purge stale runner scale sets.

When the application restarts after an unclean shutdown (crash, OOMKill, pod eviction, CrashLoopBackOff), the runner scale set remains registered but offline in GitHub: 
<img width="1916" height="271" alt="Orka GitHub Runner Scale Sets" src="https://github.com/user-attachments/assets/23646b31-8a60-430b-84b7-add8bee11fdc" />


On the next startup, `CreateRunnerScaleSet` fails with:
  ``` 
  panic: unable to create runner <name>, err: 400 - had issue communicating with
  Actions backend: The runner scale set already exists in runner group Default.
  ```
This puts the pod into a permanent CrashLoopBackOff, because every restart attempt hits the same stale scale set and panics again.

Root cause: main.go unconditionally calls `CreateRunnerScaleSet` without first checking whether one already exists. The cleanup goroutine that deletes the scale set on shutdown only runs on graceful SIGTERM — it does not run when the process panics or is force-killed.

Fix: Before attempting to create a new runner scale set, call GetRunnerScaleSet (which already exists in the codebase) to check for an existing one. If found, re-use it. If not, create a new one as before.
```go
  // Before (always creates, panics if exists)
  runnerScaleSet, err := actionsClient.CreateRunnerScaleSet(ctx, &types.RunnerScaleSet{...})

  // After (get-or-create)
  runnerScaleSet, err := actionsClient.GetRunnerScaleSet(ctx, groupId, runnerName)
  if runnerScaleSet != nil {
      logger.Infof("found existing runner scale set %s (id: %d), re-using it", ...)
  } else {
      runnerScaleSet, err = actionsClient.CreateRunnerScaleSet(ctx, &types.RunnerScaleSet{...})
  }
```

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
