### PR TITLE
Track inflight provisioning

### DIFF
--- a/pkg/github/runners/message-processor.go
+++ b/pkg/github/runners/message-processor.go
@@ -105,8 +105,11 @@ func (p *RunnerMessageProcessor) processRunnerMessage(message *types.RunnerScale
 
 	p.logger.Infof("process batched runner scale set job messages with id %d and batch size %d", message.MessageId, len(batchedMessages))
 
-	requiredRunners := message.Statistics.TotalAssignedJobs - message.Statistics.TotalRegisteredRunners
+	inflight := int(p.provisioningInflight.Load())
+	requiredRunners := message.Statistics.TotalAssignedJobs - message.Statistics.TotalRegisteredRunners - inflight
 	provisionedRunners := 0
+
+	p.logger.Infof("provisioning inflight: %d, required runners: %d", inflight, requiredRunners)
 
 	if message.MessageId == 0 && len(batchedMessages) == 0 {
 		// The session-creation snapshot can lag: runners whose jobs are already
@@ -206,11 +209,13 @@ func (p *RunnerMessageProcessor) AdoptVM(vmName string) {
 }
 
 func (p *RunnerMessageProcessor) startRunner(job jobIdentity) {
+	p.provisioningInflight.Add(1)
 	var executionErr error
 
 	defer p.removeUpstreamCanceledJob(job)
 
 	executor, commands, provisioningErr := p.provisionRunnerWithRetry(p.ctx, job)
+	p.provisioningInflight.Add(-1)
 	if provisioningErr != nil {
 		if errors.Is(provisioningErr, context.Canceled) {
 			p.logger.Infof("provisioning canceled for %s", p.runnerScaleSetName)

--- a/pkg/github/runners/types.go
+++ b/pkg/github/runners/types.go
@@ -7,6 +7,7 @@ package runners
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 
 	"github.com/macstadium/orka-github-actions-integration/pkg/github/actions"
 	"github.com/macstadium/orka-github-actions-integration/pkg/github/messagequeue"
@@ -47,4 +48,5 @@ type RunnerMessageProcessor struct {
 	upstreamCanceledJobsMutex sync.RWMutex
 	runnerContextCancels      map[string]context.CancelFunc
 	runnerContextCancelsMutex sync.Mutex
+	provisioningInflight      atomic.Int32
 }


### PR DESCRIPTION
## Description

* Track inflight provisioning

This allows to limit the number of overprovisioned runners.
If there is an inflight runner and GitHub requests one - do not try to provision a new one. Wait for the inflight runner to complete.

## Testing

1. Stop the integration
2. Start a job requiring 1 or more runners
3. Start the integration
4. The integration should create only the required amount of runners, not more
5. After the workflow completes all VMs should be deleted

