### PR TITLE
Fix typo in .env for GHES repository format

### DIFF
--- a/examples/.env
+++ b/examples/.env
@@ -22,7 +22,7 @@ GITHUB_APP_PRIVATE_KEY = ""
 # GITHUB_URL="https://github.com/<account-name>/<repo-name>" where <account-name> is your account name and <repo-name> is your repo name
 # For repositories under an organization, use the format:
 # GITHUB_URL="https://github.com/<org-name>" where <org-name> is the name of your organisation
-# For Github Enterprise Self-Hosted instances (GHES) repositoroes under an organiztion, use the format: 
+# For Github Enterprise Self-Hosted instances (GHES) repositories under an organiztion, use the format: 
 # GITHUB_URL="https://<my-enterprise-github-url>/<org-name>" where <my-enterprise-github-url> is the url endpoint for your GHES instance,
 # and <org-name> is the name of your organization in the GHES instance
 GITHUB_URL="https://github.com/macstadium"


### PR DESCRIPTION
Fix typo